### PR TITLE
Adding distance prior

### DIFF
--- a/phat_small/datamodel.py
+++ b/phat_small/datamodel.py
@@ -144,18 +144,18 @@ noisefile = project + "/" + project + "_noisemodel.grid.hd5"
 # absflux calibration covariance matrix for HST specific filters (AC)
 absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 
-# Distances: distance to the galaxy [min, max, step] or [fixed number]
-distances = [24.47]
-
-# Distance unit (any length or units.mag)
-distance_unit = units.mag
-
 # velocity of galaxy
 velocity = -300 * units.km / units.s  # M31 velocity from SIMBAD
 
 ################
 
 # Stellar grid definition
+
+# Distances: distance to the galaxy [min, max, step] or [fixed number]
+distances = [24.47]
+# Distance unit (any length or units.mag)
+distance_unit = units.mag
+distance_prior_model = {'name': 'flat'}
 
 # log10(Age) -- [min,max,step] to generate the isochrones in years
 #   example [6.0, 10.13, 1.0]

--- a/phat_small_multidistance/datamodel.py
+++ b/phat_small_multidistance/datamodel.py
@@ -130,6 +130,7 @@ absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 # Andromeda: 778 ± 33 kpc. Fit within range of 66 kpc. 10 steps --> 6.6 kpc
 distances = [(778.0 - 33.0) * 1.0e3, (778.0 + 33.0) * 1.0e3, 6.6e3]
 distance_unit = units.pc
+distance_prior_model = {'name': 'flat'}
 
 # Stellar grid definition
 
@@ -139,6 +140,7 @@ logt = [6.0, 10.13, 1.0]
 
 # note: Mass is not sampled, instead the isochrone supplied
 #       mass spacing is used instead
+mass_prior_model = {"name": "kroupa"}
 
 # Metallicity : list of floats
 #   Here: Z == Z_initial, NOT Z(t) surface abundance
@@ -146,6 +148,7 @@ logt = [6.0, 10.13, 1.0]
 #   example z = [0.03, 0.019, 0.008, 0.004]
 #   can they be set as [min, max, step]?
 z = [0.03, 0.019, 0.008, 0.004]
+met_prior_model = {"name": "flat"}
 
 # Isochrone Model Grid
 #   Current Choices: Padova or MIST

--- a/production_runs_2019/datamodel.py
+++ b/production_runs_2019/datamodel.py
@@ -172,9 +172,9 @@ n_subgrid = 10
 
 # Distances: distance to the galaxy [min, max, step] or [fixed number]
 distances = [24.36]
-
 # Distance unit (any length or units.mag)
 distance_unit = units.mag
+distance_prior_model = {'name': 'flat'}
 
 # velocity of galaxy
 velocity = -236 * units.km / units.s
@@ -186,9 +186,11 @@ velocity = -236 * units.km / units.s
 # log10(Age) -- [min,max,step] to generate the isochrones in years
 #   example [6.0, 10.13, 1.0]
 logt = [6.0, 10.13, 0.1]
+age_prior_model = {'name': 'flat'}
 
 # note: Mass is not sampled, instead the isochrone supplied
 #       mass spacing is used instead
+mass_prior_model = {"name": "kroupa"}
 
 # Metallicity : list of floats
 #   Here: Z == Z_initial, NOT Z(t) surface abundance
@@ -198,6 +200,7 @@ logt = [6.0, 10.13, 0.1]
 z = (
     10 ** np.array([-2.1, -1.8, -1.5, -1.2, -0.9, -0.6, -0.3, 0.0, 0.3]) * 0.0152
 ).tolist()
+met_prior_model = {"name": "flat"}
 
 # Isochrone Model Grid
 #   Current Choices: Padova or MIST


### PR DESCRIPTION
Now that the BEAST supports a distance prior - need to add the flat prior to the examples.  For some of the examples, the priors for the rest of the stellar parameters are added as well for consistency.