### PR TITLE
update 2D PDFs for phat_small

### DIFF
--- a/phat_small/run_beast.py
+++ b/phat_small/run_beast.py
@@ -118,7 +118,12 @@ if __name__ == "__main__":
 
     if args.fit:
 
-        run_fitting.run_fitting(use_sd=False, nsubs=1, nprocs=1)
+        run_fitting.run_fitting(
+            use_sd=False,
+            nsubs=1,
+            nprocs=1,
+            pdf2d_param_list=['Av', 'M_ini', 'logT']
+        )
 
     if args.resume:
 


### PR DESCRIPTION
The phat_small example will now only save the 2D PDFs for `Av`, `M_ini`, and `logT`, which are currently the only ones used in `beast.tools.star_type_probability`.