### PR TITLE
ensure that phat_small runs with max of 50 PDF bins

### DIFF
--- a/phat_small/run_beast.py
+++ b/phat_small/run_beast.py
@@ -122,7 +122,8 @@ if __name__ == "__main__":
             use_sd=False,
             nsubs=1,
             nprocs=1,
-            pdf2d_param_list=['Av', 'M_ini', 'logT']
+            pdf2d_param_list=['Av', 'M_ini', 'logT'],
+            pdf_max_nbins=50,
         )
 
     if args.resume:


### PR DESCRIPTION
https://github.com/BEAST-Fitting/beast/pull/571 is updating the default maximum number of 1D/2D PDF bins from 50 to 100.  This PR changes the call to `run_fitting` in `phat_small/run_beast.py` to still have a max of 50 bins.