### PR TITLE
Added source density binning parameters to the beast_settings file

### DIFF
--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -2,6 +2,7 @@
 # BEAST datamodel for the example based on M31 PHAT data
 # """
 import numpy as np
+
 from astropy import units
 
 # BEAST imports
@@ -10,61 +11,237 @@ from beast.physicsmodel.stars import stellib
 from beast.physicsmodel.dust import extinction
 from beast.observationmodel.noisemodel import absflux_covmat
 
-# condensed settings just for simulations
-# (see beast-examples/phat_small for beast_settings.txt with extensive comments)
+# from extra_filters import make_integration_filter, make_top_hat_filter
 
-project = "beast_metal_small"
+# -----------------------------------------------------------------
+# User inputs                                   [sec:conf]
+# -----------------------------------------------------------------
+# Parameters that are required to make models
+# and to fit the data
+# -----------------------------------------------------------------
+# AC == authomatically created
+# indicates where user's input change is NOT necessary/recommeded
+# -----------------------------------------------------------------
 
-surveyname = "METAL"
+# project : string
+#   the name of the output results directory
+project = "beast_example_phat"
 
-filters = ['HST_WFC3_F225W', 'HST_WFC3_F275W','HST_WFC3_F336W',
-           'HST_ACS_WFC_F475W','HST_ACS_WFC_F814W',
-           'HST_WFC3_F110W','HST_WFC3_F160W']
+# name of the survey
+#  used for the creation of the unique name for each source
+surveyname = "PHAT"
 
-basefilters = ["F225W", "F275W", "F336W", "F475W", "F814W", "F110W", "F160W"]
-obs_colnames = [f.upper() + "_RATE" for f in basefilters]
+# filters : list of strings
+#   full filter names in BEAST filter database
+filters = [
+    "HST_WFC3_F275W",
+    "HST_WFC3_F336W",
+    "HST_ACS_WFC_F475W",
+    "HST_ACS_WFC_F814W",
+    "HST_WFC3_F110W",
+    "HST_WFC3_F160W",
+]
 
-# not needed?
-obsfile = "data/14675_LMC-13361nw-11112.gst_samp.fits"
+# basefilters : list of strings
+#   short names for filters
+basefilters = ["F275W", "F336W", "F475W", "F814W", "F110W", "F160W"]
 
-## observation(noise) model
+# obs_colnames : list of strings
+#   names of columns for filters in the observed catalog
+#   need to match column names in the observed catalog,
+#   input data MUST be in fluxes, NOT in magnitudes
+#   fluxes MUST be in normalized Vega units
+obs_colnames = [f.lower() + "_rate" for f in basefilters]
+# obs_colnames = [ f.upper() + '_RATE' for f in basefilters ]
 
-astfile = "data/14675_LMC-13361nw-11112.gst.fake.fits"
+# obsfile : string
+#   pathname of the observed catalog
+obsfile = "data/b15_4band_det_27_A.fits"
+
+#----------------------------------
+# Source Density Binning Parameters
+#----------------------------------
+# The following parameters determine how source density bins are determined
+# from the source density image, either by the number of bins (sd_Nbins) or
+# by the bin width (sd_binwidth). This can be used for generating AST inputs,
+# and is definitely used for splitting the observed and AST catlogs for
+# fitting speed. Parameters gathered here to make sure they are consistent
+# across the full workflow.
+
+# sd_binwidth : integer
+# Source density bin width.
+sd_binwidth = 1
+
+# sd_Nbins : integer
+# Number of source density bins.
+sd_Nbins = None
+
+# ------------------------------------------------------
+# Artificial Star Test Input File Generation Parameters
+# ------------------------------------------------------
+
+# ast_models_selected_per_age : integer
+# Number of models to pick per age (Default = 70).
+ast_models_selected_per_age = 70
+
+# ast_bands_above_maglimit : integer
+# Number of filters that must be above the magnitude limit
+# for an AST to be included in the list (Default = 3)
+ast_bands_above_maglimit = 3
+
+
+# ast_realization_per_model : integer
+# Number of Realizations of each included AST model
+# to be put into the list. (Default = 20)
+ast_realization_per_model = 20
+
+
+# ast_maglimit : float (single value or array with one value per filter)
+# (1) option 1: [number] to change the number of mags fainter than
+#                  the 90th percentile
+#               faintest star in the photometry catalog to be used for
+#                  the mag cut.
+#               (Default = 1)
+# (2) option 2: [space-separated list of numbers] to set custom faint end limits
+#               (one value for each band).
+ast_maglimit = [1.0]
+
+# ast_with_positions :  (bool,optional)
+# If True, the ast list is produced with X,Y positions.
+# If False, the ast list is produced with only magnitudes.
+ast_with_positions = True
+
+# ast_density_table :  (string,optional)
+# Name of density table created by
+# tools/create_background_density_map.py, containing either the source
+# density map or the background density map. If supplied, the ASTs will
+# be repeated for each density bin in the table
+ast_density_table = None
+# ast_density_table = 'data/b15_4band_det_27_A_sourcedens_map.hd5'
+
+# ast_N_bins : (int, optional)
+# Number of source or background bins that you want ASTs repeated over
+# ast_N_bins = 8
+
+# ast_pixel_distribution : float (optional)
+# (Used if ast_with_positions is True), minimum pixel separation between AST
+# position and catalog star used to determine the AST spatial distribution
+ast_pixel_distribution = 10.0
+
+# ast_reference_image : string (optional, but required if ast_with_positions
+# is True and no X and Y information  is present in the photometry catalog)
+# Name of the reference image used by DOLPHOT when running the measured
+# photometry.
+ast_reference_image = None
+
+# ast_coord_boundary : None, or list of two arrays (optional)
+# If supplied, these RA/Dec coordinates will be used to limit the region
+# over which ASTs are generated.  Input should be list of two arrays, the
+# first RA and the second Dec, ordered sequentially around the region
+# (either CW or CCW).
+ast_coord_boundary = None
+
+# -------------------------------------------
+# Noise Model Artificial Star Test Parameters
+# -------------------------------------------
+
+# astfile : string
+#   pathname of the AST files (single camera ASTs)
+astfile = "data/fake_stars_b15_27_all.hd5"
+
+# ast_colnames : list of strings
+#   names of columns for filters in the AST catalog (AC)
 ast_colnames = np.array(basefilters)
+
+# noisefile : string
+#   create a name for the noise model
 noisefile = project + "/" + project + "_noisemodel.grid.hd5"
+
+# absflux calibration covariance matrix for HST specific filters (AC)
 absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 
-## physics grid
+# -------------------------------------------
+# Grid
+# -------------------------------------------
 
+# n_subgrid : integer
+#     Number of sub-grids to use (1 means no subgrids).  These are
+#     useful when the physics model grid is too large to read into
+#     memory.
 n_subgrid = 1
 
-# stars
+################
 
-velocity = 262.2 * units.km / units.s  # LMC velocity from SIMBAD
-distances = [18.5]
+# Distance/Velocity
+
+# velocity of galaxy
+velocity = -300 * units.km / units.s  # M31 velocity from SIMBAD
+
+# Distances: distance to the galaxy [min, max, step] or [fixed number]
+distances = [24.47]
+# Distance unit (any length or units.mag)
 distance_unit = units.mag
 distance_prior_model = {'name': 'flat'}
 
+################
+
+# Stellar grid definition
+
+# log10(Age) -- [min,max,step] to generate the isochrones in years
+#   example [6.0, 10.13, 1.0]
 logt = [6.0, 10.13, 1.0]
 age_prior_model = {'name': 'flat'}
+
+# note: Mass is not sampled, instead the isochrone supplied
+#       mass spacing is used instead
 mass_prior_model = {"name": "kroupa"}
-# metallicities given as relative to solar which has 0.0152 (Z_solar)
-z = (10 ** np.array([-2.1, -1.5, -0.9, -0.3]) * 0.0152).tolist()
+
+# Metallicity : list of floats
+#   Here: Z == Z_initial, NOT Z(t) surface abundance
+#   PARSECv1.2S accepts values 1.e-4 < Z < 0.06
+#   example z = [0.03, 0.019, 0.008, 0.004]
+#   can they be set as [min, max, step]?
+z = [0.03, 0.019, 0.008, 0.004]
 met_prior_model = {"name": "flat"}
 
+#   Current Choices: Padova or MIST
+#   PadovaWeb() -- `modeltype` param for iso sets from ezpadova
+#      (choices: parsec12s_r14, parsec12s, 2010, 2008, 2002)
+#   MISTWeb() -- `rotation` param (choices: vvcrit0.0=default, vvcrit0.4)
+#
+# Default: PARSEC+COLIBRI
 oiso = isochrone.PadovaWeb()
+# Alternative: PARSEC1.2S -- old grid parameters
+# oiso = isochrone.PadovaWeb(modeltype='parsec12s', filterPMS=True)
+# Alternative: MIST -- v1, no rotation
+# oiso = isochrone.MISTWeb()
+
+# Stellar Atmospheres library definition
 osl = stellib.Tlusty() + stellib.Kurucz()
 
-# dust
+################
 
+# Dust extinction grid definition
 extLaw = extinction.Gordon16_RvFALaw()
+
+# A(V): dust column in magnitudes
+#   acceptable avs > 0.0
+#   example [min, max, step] = [0.0, 10.055, 1.0]
 avs = [0.0, 10.055, 1.0]
 av_prior_model = {"name": "flat"}
+
+# R(V): dust average grain size
+#   example [min, max, step] = [2.0,6.0,1.0]
 rvs = [2.0, 6.0, 1.0]
 rv_prior_model = {"name": "flat"}
+
+# fA: mixture factor between "MW" and "SMCBar" extinction curves
+#   example [min, max, step] = [0.0,1.0, 0.25]
 fAs = [0.0, 1.0, 0.25]
 fA_prior_model = {"name": "flat"}
 
-## misc
+################
 
+# add in the standard filters to enable output of stats and pdf1d values
+# for the observed fitlers (AC)
 add_spectral_properties_kwargs = dict(filternames=filters)

--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -2,7 +2,6 @@
 # BEAST datamodel for the example based on M31 PHAT data
 # """
 import numpy as np
-
 from astropy import units
 
 # BEAST imports
@@ -11,237 +10,82 @@ from beast.physicsmodel.stars import stellib
 from beast.physicsmodel.dust import extinction
 from beast.observationmodel.noisemodel import absflux_covmat
 
-# from extra_filters import make_integration_filter, make_top_hat_filter
+# condensed settings just for simulations
+# (see beast-examples/phat_small for beast_settings.txt with extensive comments)
 
-# -----------------------------------------------------------------
-# User inputs                                   [sec:conf]
-# -----------------------------------------------------------------
-# Parameters that are required to make models
-# and to fit the data
-# -----------------------------------------------------------------
-# AC == authomatically created
-# indicates where user's input change is NOT necessary/recommeded
-# -----------------------------------------------------------------
+project = "beast_metal_small"
 
-# project : string
-#   the name of the output results directory
-project = "beast_example_phat"
+surveyname = "METAL"
 
-# name of the survey
-#  used for the creation of the unique name for each source
-surveyname = "PHAT"
+filters = ['HST_WFC3_F225W', 'HST_WFC3_F275W','HST_WFC3_F336W',
+           'HST_ACS_WFC_F475W','HST_ACS_WFC_F814W',
+           'HST_WFC3_F110W','HST_WFC3_F160W']
 
-# filters : list of strings
-#   full filter names in BEAST filter database
-filters = [
-    "HST_WFC3_F275W",
-    "HST_WFC3_F336W",
-    "HST_ACS_WFC_F475W",
-    "HST_ACS_WFC_F814W",
-    "HST_WFC3_F110W",
-    "HST_WFC3_F160W",
-]
+basefilters = ["F225W", "F275W", "F336W", "F475W", "F814W", "F110W", "F160W"]
+obs_colnames = [f.upper() + "_RATE" for f in basefilters]
 
-# basefilters : list of strings
-#   short names for filters
-basefilters = ["F275W", "F336W", "F475W", "F814W", "F110W", "F160W"]
+# not needed?
+obsfile = "data/14675_LMC-13361nw-11112.gst_samp.fits"
 
-# obs_colnames : list of strings
-#   names of columns for filters in the observed catalog
-#   need to match column names in the observed catalog,
-#   input data MUST be in fluxes, NOT in magnitudes
-#   fluxes MUST be in normalized Vega units
-obs_colnames = [f.lower() + "_rate" for f in basefilters]
-# obs_colnames = [ f.upper() + '_RATE' for f in basefilters ]
-
-# obsfile : string
-#   pathname of the observed catalog
-obsfile = "data/b15_4band_det_27_A.fits"
-
-#----------------------------------
-# Source Density Binning Parameters
-#----------------------------------
-# The following parameters determine how source density bins are determined
-# from the source density image, either by the number of bins (sd_Nbins) or
-# by the bin width (sd_binwidth). This can be used for generating AST inputs,
-# and is definitely used for splitting the observed and AST catlogs for
-# fitting speed. Parameters gathered here to make sure they are consistent
-# across the full workflow.
-
-# sd_binwidth : integer
-# Source density bin width.
+## source density binning
 sd_binwidth = 1
-
-# sd_Nbins : integer
-# Number of source density bins.
 sd_Nbins = None
 
-# ------------------------------------------------------
-# Artificial Star Test Input File Generation Parameters
-# ------------------------------------------------------
+## artificial star tests
 
-# ast_models_selected_per_age : integer
-# Number of models to pick per age (Default = 70).
 ast_models_selected_per_age = 70
-
-# ast_bands_above_maglimit : integer
-# Number of filters that must be above the magnitude limit
-# for an AST to be included in the list (Default = 3)
 ast_bands_above_maglimit = 3
-
-
-# ast_realization_per_model : integer
-# Number of Realizations of each included AST model
-# to be put into the list. (Default = 20)
-ast_realization_per_model = 20
-
-
-# ast_maglimit : float (single value or array with one value per filter)
-# (1) option 1: [number] to change the number of mags fainter than
-#                  the 90th percentile
-#               faintest star in the photometry catalog to be used for
-#                  the mag cut.
-#               (Default = 1)
-# (2) option 2: [space-separated list of numbers] to set custom faint end limits
-#               (one value for each band).
+ast_n_flux_bins = 40
+ast_n_per_flux_bin = 50
+ast_realization_per_model = 1
 ast_maglimit = [1.0]
-
-# ast_with_positions :  (bool,optional)
-# If True, the ast list is produced with X,Y positions.
-# If False, the ast list is produced with only magnitudes.
 ast_with_positions = True
-
-# ast_density_table :  (string,optional)
-# Name of density table created by
-# tools/create_background_density_map.py, containing either the source
-# density map or the background density map. If supplied, the ASTs will
-# be repeated for each density bin in the table
 ast_density_table = None
-# ast_density_table = 'data/b15_4band_det_27_A_sourcedens_map.hd5'
-
-# ast_N_bins : (int, optional)
-# Number of source or background bins that you want ASTs repeated over
 # ast_N_bins = 8
-
-# ast_pixel_distribution : float (optional)
-# (Used if ast_with_positions is True), minimum pixel separation between AST
-# position and catalog star used to determine the AST spatial distribution
 ast_pixel_distribution = 10.0
-
-# ast_reference_image : string (optional, but required if ast_with_positions
-# is True and no X and Y information  is present in the photometry catalog)
-# Name of the reference image used by DOLPHOT when running the measured
-# photometry.
 ast_reference_image = None
-
-# ast_coord_boundary : None, or list of two arrays (optional)
-# If supplied, these RA/Dec coordinates will be used to limit the region
-# over which ASTs are generated.  Input should be list of two arrays, the
-# first RA and the second Dec, ordered sequentially around the region
-# (either CW or CCW).
 ast_coord_boundary = None
+ast_supplement = None
+ast_erode_selection_region = 0.5
 
-# -------------------------------------------
-# Noise Model Artificial Star Test Parameters
-# -------------------------------------------
+## observation(noise) model
 
-# astfile : string
-#   pathname of the AST files (single camera ASTs)
-astfile = "data/fake_stars_b15_27_all.hd5"
-
-# ast_colnames : list of strings
-#   names of columns for filters in the AST catalog (AC)
+astfile = "data/14675_LMC-13361nw-11112.gst.fake.fits"
 ast_colnames = np.array(basefilters)
-
-# noisefile : string
-#   create a name for the noise model
 noisefile = project + "/" + project + "_noisemodel.grid.hd5"
-
-# absflux calibration covariance matrix for HST specific filters (AC)
 absflux_a_matrix = absflux_covmat.hst_frac_matrix(filters)
 
-# -------------------------------------------
-# Grid
-# -------------------------------------------
+## physics grid
 
-# n_subgrid : integer
-#     Number of sub-grids to use (1 means no subgrids).  These are
-#     useful when the physics model grid is too large to read into
-#     memory.
 n_subgrid = 1
 
-################
+# stars
 
-# Distance/Velocity
-
-# velocity of galaxy
-velocity = -300 * units.km / units.s  # M31 velocity from SIMBAD
-
-# Distances: distance to the galaxy [min, max, step] or [fixed number]
-distances = [24.47]
-# Distance unit (any length or units.mag)
+velocity = 262.2 * units.km / units.s  # LMC velocity from SIMBAD
+distances = [18.5]
 distance_unit = units.mag
 distance_prior_model = {'name': 'flat'}
 
-################
-
-# Stellar grid definition
-
-# log10(Age) -- [min,max,step] to generate the isochrones in years
-#   example [6.0, 10.13, 1.0]
 logt = [6.0, 10.13, 1.0]
 age_prior_model = {'name': 'flat'}
-
-# note: Mass is not sampled, instead the isochrone supplied
-#       mass spacing is used instead
 mass_prior_model = {"name": "kroupa"}
-
-# Metallicity : list of floats
-#   Here: Z == Z_initial, NOT Z(t) surface abundance
-#   PARSECv1.2S accepts values 1.e-4 < Z < 0.06
-#   example z = [0.03, 0.019, 0.008, 0.004]
-#   can they be set as [min, max, step]?
-z = [0.03, 0.019, 0.008, 0.004]
+# metallicities given as relative to solar which has 0.0152 (Z_solar)
+z = (10 ** np.array([-2.1, -1.5, -0.9, -0.3]) * 0.0152).tolist()
 met_prior_model = {"name": "flat"}
 
-#   Current Choices: Padova or MIST
-#   PadovaWeb() -- `modeltype` param for iso sets from ezpadova
-#      (choices: parsec12s_r14, parsec12s, 2010, 2008, 2002)
-#   MISTWeb() -- `rotation` param (choices: vvcrit0.0=default, vvcrit0.4)
-#
-# Default: PARSEC+COLIBRI
 oiso = isochrone.PadovaWeb()
-# Alternative: PARSEC1.2S -- old grid parameters
-# oiso = isochrone.PadovaWeb(modeltype='parsec12s', filterPMS=True)
-# Alternative: MIST -- v1, no rotation
-# oiso = isochrone.MISTWeb()
-
-# Stellar Atmospheres library definition
 osl = stellib.Tlusty() + stellib.Kurucz()
 
-################
+# dust
 
-# Dust extinction grid definition
 extLaw = extinction.Gordon16_RvFALaw()
-
-# A(V): dust column in magnitudes
-#   acceptable avs > 0.0
-#   example [min, max, step] = [0.0, 10.055, 1.0]
 avs = [0.0, 10.055, 1.0]
 av_prior_model = {"name": "flat"}
-
-# R(V): dust average grain size
-#   example [min, max, step] = [2.0,6.0,1.0]
 rvs = [2.0, 6.0, 1.0]
 rv_prior_model = {"name": "flat"}
-
-# fA: mixture factor between "MW" and "SMCBar" extinction curves
-#   example [min, max, step] = [0.0,1.0, 0.25]
 fAs = [0.0, 1.0, 0.25]
 fA_prior_model = {"name": "flat"}
 
-################
+## misc
 
-# add in the standard filters to enable output of stats and pdf1d values
-# for the observed fitlers (AC)
 add_spectral_properties_kwargs = dict(filternames=filters)

--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -28,8 +28,10 @@ obs_colnames = [f.upper() + "_RATE" for f in basefilters]
 obsfile = "data/14675_LMC-13361nw-11112.gst_samp.fits"
 
 ## source density binning
+sd_binmode = 'linear'
 sd_binwidth = 1
 sd_Nbins = None
+sd_custom = None
 
 ## artificial star tests
 

--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -69,7 +69,7 @@ distance_unit = units.mag
 distance_prior_model = {'name': 'flat'}
 
 logt = [6.0, 10.13, 1.0]
-age_prior_model = {'name': 'flat'}
+age_prior_model = {'name': 'flat', "sfr": 1e-5}
 mass_prior_model = {"name": "kroupa"}
 # metallicities given as relative to solar which has 0.0152 (Z_solar)
 z = (10 ** np.array([-2.1, -1.5, -0.9, -0.3]) * 0.0152).tolist()

--- a/phat_small/beast_settings.txt
+++ b/phat_small/beast_settings.txt
@@ -63,10 +63,14 @@ obsfile = "data/b15_4band_det_27_A.fits"
 #----------------------------------
 # The following parameters determine how source density bins are determined
 # from the source density image, either by the number of bins (sd_Nbins) or
-# by the bin width (sd_binwidth). This can be used for generating AST inputs,
-# and is definitely used for splitting the observed and AST catlogs for
-# fitting speed. Parameters gathered here to make sure they are consistent
-# across the full workflow.
+# by the bin width (sd_binwidth). If neither parameter is set, the bins
+# will be estimated using the minimum and maximum source density values
+# and bins of 1 source per square arcsecond. If both parameters are set,
+# currently the bin width parameter will be used to estimate the binning
+# (via beast/tools/density_map).
+# This can be used for generating AST inputs, and is definitely used for
+# splitting the observed and AST catlogs for fitting speed. Parameters gathered
+# here to make sure they are consistent across the full workflow.
 
 # sd_binwidth : integer
 # Source density bin width.

--- a/phat_small/beast_settings.txt
+++ b/phat_small/beast_settings.txt
@@ -58,6 +58,24 @@ obs_colnames = [f.lower() + "_rate" for f in basefilters]
 #   pathname of the observed catalog
 obsfile = "data/b15_4band_det_27_A.fits"
 
+#----------------------------------
+# Source Density Binning Parameters
+#----------------------------------
+# The following parameters determine how source density bins are determined
+# from the source density image, either by the number of bins (sd_Nbins) or
+# by the bin width (sd_binwidth). This can be used for generating AST inputs,
+# and is definitely used for splitting the observed and AST catlogs for
+# fitting speed. Parameters gathered here to make sure they are consistent
+# across the full workflow.
+
+# sd_binwidth : integer
+# Source density bin width.
+sd_binwidth = 1
+
+# sd_Nbins : integer
+# Number of source density bins.
+sd_Nbins = None
+
 # ------------------------------------------------------
 # Artificial Star Test Input File Generation Parameters
 # ------------------------------------------------------

--- a/phat_small/beast_settings.txt
+++ b/phat_small/beast_settings.txt
@@ -62,23 +62,42 @@ obsfile = "data/b15_4band_det_27_A.fits"
 # Source Density Binning Parameters
 #----------------------------------
 # The following parameters determine how source density bins are determined
-# from the source density image, either by the number of bins (sd_Nbins) or
-# by the bin width (sd_binwidth). If neither parameter is set, the bins
+# from the source density image. The two mode options for binning are linear
+# and log. If the mode is "log", the number of bins parameter (sd_Nbins)
+# will determine the binning. If "linear", either the number of bins (sd_Nbins)
+# or the bin width (sd_binwidth) can be used to determine the binning.
+# If "linear" and neither sd_Nbins or sd_binwidth is set, the bins
 # will be estimated using the minimum and maximum source density values
-# and bins of 1 source per square arcsecond. If both parameters are set,
-# currently the bin width parameter will be used to estimate the binning
-# (via beast/tools/density_map).
-# This can be used for generating AST inputs, and is definitely used for
-# splitting the observed and AST catlogs for fitting speed. Parameters gathered
-# here to make sure they are consistent across the full workflow.
+# and bins of 1 source per square arcsecond. If both  sd_Nbins or sd_binwidth
+# are set, currently the bin width parameter will be used to estimate the
+# binning (via beast/tools/density_map).
+# Alternatively, the user can input custom bin edges, which overrides all
+# of the above parameters.
+# This can be used for generating AST input positions, and is used for
+# splitting the observed and AST catlogs for fitting speed. Parameters are
+# gathered here to make sure they are consistent across the full workflow.
 
-# sd_binwidth : integer
-# Source density bin width.
-sd_binwidth = 1
+# sd_binmode : string
+# Convention for source density binning, either "linear" or "log"
+# Set to 'None' if not used.
+sd_binmode= "log"
 
 # sd_Nbins : integer
-# Number of source density bins.
-sd_Nbins = None
+# (optional) Number of source density bins.
+# Set to 'None' if not used.
+sd_Nbins = 10
+
+# sd_binwidth : integer
+# (optional) Source density bin width. Used if the bin mode is linear.
+# Set to 'None' if not used.
+sd_binwidth = None
+
+# sd_custom : list (default = None)
+# (optional) List of custom bin edges to use for source density binning. Will
+# override all other source density binning parameters if set.
+# Overrides sd_binmode, sd_Nbins, and sd_binwidth.
+# Set to 'None' if not used.
+sd_custom = None
 
 # ------------------------------------------------------
 # Artificial Star Test Input File Generation Parameters


### PR DESCRIPTION
To keep things consistent across source density binning (for AST input generation, and later for splitting the observed and AST catalogs). This should be used to update the cached beast_settings file so the regression tests still work 