### PR TITLE
update AST keywords (including ast_erode_selection_region)

### DIFF
--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -27,7 +27,6 @@ obs_colnames = [f.upper() + "_RATE" for f in basefilters]
 # not needed?
 obsfile = "data/14675_LMC-13361nw-11112.gst_samp.fits"
 
-
 ## artificial star tests
 
 ast_models_selected_per_age = 70
@@ -43,7 +42,7 @@ ast_pixel_distribution = 10.0
 ast_reference_image = None
 ast_coord_boundary = None
 ast_supplement = None
-
+ast_erode_selection_region = 0.5
 
 ## observation(noise) model
 

--- a/phat_small/beast_settings.txt
+++ b/phat_small/beast_settings.txt
@@ -123,6 +123,15 @@ ast_reference_image = None
 # (either CW or CCW).
 ast_coord_boundary = None
 
+# ast_erode_selection_region : None, or float
+# You may wish to avoid placing ASTs near the edge of the image.  Set this to
+# the number of arcseconds (default=0.5, which is ~10 pixels for WFC3/UVIS) to
+# shrink the allowed AST placement region.  This is applied by doing an erosion
+# to both ast_coord_boundary (if set) and the convex hull around the photometry
+# catalog.
+ast_erode_selection_region = 0.5
+
+
 # -------------------------------------------
 # Noise Model Artificial Star Test Parameters
 # -------------------------------------------


### PR DESCRIPTION
Updates to beast_settings that go with https://github.com/BEAST-Fitting/beast/pull/654 - adding option shrink boundaries for AST placement region.  Also adds missing AST keywords to the metal_small settings.