### PR TITLE
Updates to sync generate_files_for_tests.py with BEAST test_regresscheck.py

### DIFF
--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -63,7 +63,7 @@ distance_unit = units.mag
 distance_prior_model = {'name': 'flat'}
 
 logt = [6.0, 10.13, 1.0]
-age_prior_model = {'name': 'flat'}
+age_prior_model = {'name': 'flat', "sfr": 1e-5}
 mass_prior_model = {"name": "kroupa"}
 # metallicities given as relative to solar which has 0.0152 (Z_solar)
 z = (10 ** np.array([-2.1, -1.5, -0.9, -0.3]) * 0.0152).tolist()

--- a/metal_small/generate_files_for_tests.py
+++ b/metal_small/generate_files_for_tests.py
@@ -1,8 +1,11 @@
 import os
 import copy
+import stat
+import glob
 import numpy as np
 import argparse
 import asdf
+
 
 # BEAST imports
 from beast.tools.run import (
@@ -127,7 +130,7 @@ def generate_files_for_tests(run_beast=True, run_tools=True):
                 nsubs=settings.n_subgrid,
                 nprocs=1,
                 pdf2d_param_list=["Av", "M_ini", "logT"],
-                pdf_max_nbins=50,
+                pdf_max_nbins=200,
             )
 
             # -----------------
@@ -183,8 +186,8 @@ def generate_files_for_tests(run_beast=True, run_tools=True):
 
         # run it
         output = star_type_probability.star_type_probability(
-            '{0}/{0}_pdf1d.fits'.format(settings_orig.project),
-            '{0}/{0}_pdf2d.fits'.format(settings_orig.project),
+            "{0}/{0}_pdf1d.fits".format(settings_orig.project),
+            "{0}/{0}_pdf2d.fits".format(settings_orig.project),
             **input,
         )
 
@@ -193,6 +196,20 @@ def generate_files_for_tests(run_beast=True, run_tools=True):
             "{0}/{0}_star_type_probability.asdf".format(settings_orig.project)
         )
 
+    # ==========================================
+    # asdf file permissions
+    # ==========================================
+
+    # for unknown reasons, asdf currently writes files with permissions set
+    # to -rw-------.  This changes it to -rw-r--r-- (like the rest of the
+    # BEAST files) so Karl can easily copy them over to the cached file
+    # website.
+
+    # list of asdf files
+    asdf_files = glob.glob("*/*.asdf")
+    # go through each one to change permissions
+    for fname in asdf_files:
+        os.chmod(fname, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The files created by `generate_files_for_tests` were still causing a few test failures.  I think the issues were:
* a mismatch in the max number of PDF bins
* the metal_small beast settings file was missing `sfr` in the age prior 

They also didn't have the same number of saved lnp points (though that's not tested yet, so shouldn't make a difference).

We also found on Friday that asdf files are written with weird permissions (`-rw-------` instead of `-rw-r--r--` like everything else).  I added a short bit of code that forces the latter permissions, so if someone at ST other than @karllark wants to generate reference files, @karllark can actually see them.