### PR TITLE
Toothpick use_rate keyword removed

### DIFF
--- a/metal_small/beast_settings.txt
+++ b/metal_small/beast_settings.txt
@@ -46,7 +46,7 @@ distance_unit = units.mag
 distance_prior_model = {'name': 'flat'}
 
 logt = [6.0, 10.13, 1.0]
-age_prior_model = {'name': 'flat'}
+age_prior_model = {'name': 'flat', "sfr": 1e-5}
 mass_prior_model = {"name": "kroupa"}
 # metallicities given as relative to solar which has 0.0152 (Z_solar)
 z = (10 ** np.array([-2.1, -1.5, -0.9, -0.3]) * 0.0152).tolist()

--- a/metal_small/generate_files_for_tests.py
+++ b/metal_small/generate_files_for_tests.py
@@ -2,7 +2,6 @@ import os
 import copy
 import stat
 import glob
-import numpy as np
 import argparse
 import asdf
 
@@ -79,7 +78,6 @@ def generate_files_for_tests(run_beast=True, run_tools=True):
                 use_sd=False,
                 nsubs=settings.n_subgrid,
                 nprocs=1,
-                use_rate=True,
             )
 
             # -----------------

--- a/metal_small/run_beast.py
+++ b/metal_small/run_beast.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         print("Generating noise model from ASTs and absflux A matrix")
 
         create_obsmodel.create_obsmodel(
-            settings, use_sd=False, nsubs=settings.n_subgrid, nprocs=1, use_rate=True,
+            settings, use_sd=False, nsubs=settings.n_subgrid, nprocs=1,
         )
 
         # in the absence of ASTs, the splinter noise model can be used


### PR DESCRIPTION
Has been removed from the toothpick observation model generation.  (Now the only option!).